### PR TITLE
Fix small versioning issue

### DIFF
--- a/client/comparison-extension/package.json
+++ b/client/comparison-extension/package.json
@@ -50,7 +50,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "lint": "eslint -c ./.eslintrc.js --ext .ts,.tsx ./src",
-    "publish:next": "VERSION_NUMBER=$npm_package_version-next.$(date +%Y%m%d.%H%M%S) && yarn publish --access public --tag next --new-version $VERSION_NUMBER --no-git-tag-version"
+    "publish:next": "VERSION_NUMBER=$npm_package_version-next.$(date +%Y%m%d-%H%M%S) && yarn publish --access public --tag next --new-version $VERSION_NUMBER --no-git-tag-version"
   },
   "theiaExtensions": [
     {


### PR DESCRIPTION
NPM does not allow versions to contain a leading 0 after '.'
This changes the '.' to a '-' to ensure publishing before 10 AM.